### PR TITLE
Remove inheritance on Contao\Controller

### DIFF
--- a/system/modules/selectModule/config/runonce.php
+++ b/system/modules/selectModule/config/runonce.php
@@ -28,7 +28,7 @@
  */
 
 
-class SelectModuleRunonce extends Controller
+class SelectModuleRunonce
 {
 
     public function run()


### PR DESCRIPTION
Currently the following error will occur during `contao:migrate`:

```
 [Error]
  Call to protected Contao\System::__construct() from context 'Contao\CoreBundle\Command\MigrateCommand'  


Exception trace:
  at vendor\menatwork\selectmodule\system\modules\selectModule\config\runonce.php:59
 include() at vendor\contao\contao\core-bundle\src\Command\MigrateCommand.php:275
```

This is because the migration class extends from `Contao\Controller` and does not provide its own constructor (the parent constructor is protected). Since the migration class does not actually use anything from `Contao\Controller` (or `Contao\System`) via its object instance, the inheritance can simply be removed to fix it.